### PR TITLE
Feature/move mvn truststore opts

### DIFF
--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -54,7 +54,9 @@ if [ ! -f "${CLI_CONFIG_FILE}" ]; then
 fi
 
 # Set maven truststore options in .mavenrc file so they won't get copied to slave machines
-echo "export MAVEN_OPTS=\"\$MAVEN_OPTS-Djavax.net.ssl.trustStore=/var/lib/jenkins/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit\"" > /var/lib/jenkins/.mavenrc
+if [[ ! -e /var/lib/jenkins/.mavenrc ]]; then
+  echo "export MAVEN_OPTS=\"\$MAVEN_OPTS-Djavax.net.ssl.trustStore=/var/lib/jenkins/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit\"" > /var/lib/jenkins/.mavenrc
+fi
 
 # starting jenkins
 java -Djava.awt.headless=true \

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -20,7 +20,7 @@ create-ca-certificates.sh /var/lib/jenkins/ca-certificates.crt
 
 # copy init scripts
 
-# remove old folder to be sure, 
+# remove old folder to be sure,
 # that it contains no script which is already removed from custom init script folder
 if [ -d "${INIT_SCRIPT_FOLDER}" ]; then
   rm -rf "${INIT_SCRIPT_FOLDER}"
@@ -52,6 +52,9 @@ if [ ! -f "${CLI_CONFIG_FILE}" ]; then
 	cp /var/tmp/resources/jenkins.CLI.xml "${CLI_CONFIG_FILE}"
 	chmod 0644 "${CLI_CONFIG_FILE}"
 fi
+
+# Set maven truststore options in .mavenrc file so they won't get copied to slave machines
+echo "export MAVEN_OPTS=\"\$MAVEN_OPTS-Djavax.net.ssl.trustStore=/var/lib/jenkins/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit\"" > /var/lib/jenkins/.mavenrc
 
 # starting jenkins
 java -Djava.awt.headless=true \

--- a/resources/var/tmp/resources/init.groovy.d/init080mavenopts.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/init080mavenopts.groovy
@@ -5,8 +5,7 @@ import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 def jenkins = Jenkins.getInstance();
 
 def opts = "-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true "
-opts    += "-Djavax.net.ssl.trustStore=/var/lib/jenkins/truststore.jks "
-opts    += "-Djavax.net.ssl.trustStorePassword=changeit"
+// Additional truststore options are set in .mavenrc file
 
 def found = false;
 def globalNodeProperties = jenkins.getGlobalNodeProperties();

--- a/resources/var/tmp/resources/init.groovy.d/init090mavenautoinstall.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/init090mavenautoinstall.groovy
@@ -11,20 +11,21 @@ def mavenName = "M3"
 def mavenVersion = "3.5.0"
 
 def boolean isMavenAlreadyInstalled(def mavenName) {
+  def returnValue = false
   def descriptor = Jenkins.instance.getDescriptor("hudson.tasks.Maven")
   def installations = descriptor.getInstallations()
   if (installations != null) {
     installations.each { installation ->
       def inst = "${installation}"
       if (inst.contains(mavenName)) {
-        return true
+        returnValue = true
       }
     }
   }
-  return false
+  return returnValue
 }
 
-def createMavenInstallation(def mavenName, def mavenVersion) { 
+def createMavenInstallation(def mavenName, def mavenVersion) {
   def mvnInstaller = new Maven.MavenInstaller(mavenVersion)
   def instSourcProp = new InstallSourceProperty([mvnInstaller])
   return new Maven.MavenInstallation(mavenName, null, [instSourcProp])


### PR DESCRIPTION
Truststore specific maven opts are moved to a .mavenrc file so they won't get copied to jenkins slaves, because there the paths are incorrect.