### PR TITLE
Jenkins 2.138.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM registry.cloudogu.com/official/java:8u171-1
 
 LABEL NAME="official/jenkins" \
-      VERSION="2.138.3" \
+      VERSION="2.138.4" \
       maintainer="sebastian.sdorra@cloudogu.com"
 # Dockerfile based on https://github.com/cloudbees/jenkins-ci.org-docker/blob/f313389f8ab728d7b4207da36804ea54415c830b/1.580.1/Dockerfile
 
@@ -11,7 +11,7 @@ ENV JENKINS_HOME=/var/lib/jenkins \
     # mark as webapp for nginx
     SERVICE_TAGS=webapp \
     # jenkins version
-    JENKINS_VERSION=2.138.3 \
+    JENKINS_VERSION=2.138.4 \
     # glibc for alpine version
     GLIBC_VERSION=2.28-r0
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/dogu-build-lib@ed132d8', 'github.com/cloudogu/zalenium-build-lib@d8b74327']) _
+@Library(['github.com/cloudogu/dogu-build-lib@1e5e2a6', 'github.com/cloudogu/zalenium-build-lib@d8b74327']) _
 import com.cloudogu.ces.dogubuildlib.*
 
 node('vagrant') {

--- a/dogu.json
+++ b/dogu.json
@@ -27,6 +27,12 @@
     "Group": "1000",
     "NeedsBackup": true
   }],
+  "ExposedCommands": [
+    {
+      "Name": "upgrade-notification",
+      "Command": "/upgrade-notification.sh"
+    }
+  ],
   "HealthChecks": [{
     "Type": "tcp",
     "Port": 8080

--- a/dogu.json
+++ b/dogu.json
@@ -1,6 +1,6 @@
 {
   "Name": "official/jenkins",
-  "Version": "2.138.3-1",
+  "Version": "2.138.4-1",
   "DisplayName": "Jenkins CI",
   "Description": "Jenkins Continious Integration Server",
   "Category": "Development Apps",

--- a/resources/upgrade-notification.sh
+++ b/resources/upgrade-notification.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+FROM_VERSION="${1}"
+TO_VERSION="${2}"
+
+if [[ $TO_VERSION == 2.138.4* ]]; then
+    RED='\033[0;31m'
+    COLOR_OFF='\033[0m'
+    printf "${RED}~~~~WARNING~~~~\n\n"
+    printf "${COLOR_OFF}After applying this upgrade, Jenkins will migrate the user records to a slightly different storage format that uses a central index to map user IDs to directory names. This is a backwards incompatible change, so older releases of Jenkins will not be able to deal with the new storage format. We strongly recommend taking a full backup of at least the \$JENKINS_HOME/users/ directory before upgrading.\n\n"
+    printf "For more information see %s \n\n" "https://jenkins.io/doc/upgrade-guide/2.138/#upgrading%20to%20jenkins%20lts%202.138.4"
+fi


### PR DESCRIPTION
Upgrade to Jenkins 2.138.4 LTS
Add upgrade warning for [backwards incompatible change](https://jenkins.io/doc/upgrade-guide/2.138/#upgrading%20to%20jenkins%20lts%202.138.4)