### PR TITLE
Enforce cas plugin 1.4.3

### DIFF
--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -17,9 +17,9 @@ def keyExists(String key){
 	return true
 }
 
+// Make sure CAS-Plugin version is at least 1.4.3 to work with Jenkins 2.150.2 and following
+def minimalCasPluginVersion = "1.4.3"
 boolean isCasVersionSufficient(String version) {
-    // Make sure CAS-Plugin version is at least 1.4.3 to work with Jenkins 2.150.2 and following
-    def minimalCasPluginVersion = "1.4.3"
     List minVer = minimalCasPluginVersion.tokenize('.')
     List testVer = version.tokenize('.')
     def commonIndices = Math.min(minVer.size(), testVer.size())
@@ -34,8 +34,6 @@ boolean isCasVersionSufficient(String version) {
       return testVer.size() >= minVer.size()
 }
 
-
-// action
 try {
 	pluginManager.doCheckUpdatesServer();
 } catch (IOException ex){
@@ -47,7 +45,7 @@ def currentCasPlugin = jenkins.getPluginManager().getPlugin('cas-plugin');
 if (currentCasPlugin != null) {
     def currentCasPluginVersion = currentCasPlugin.getVersion();
     if (! isCasVersionSufficient(currentCasPluginVersion)) {
-        println "CAS-Plugin version " + currentCasPluginVersion + " is to low; Upgrading plugin...";
+        println "CAS-Plugin version " + currentCasPluginVersion + " is lower than " + minimalCasPluginVersion + "; Upgrading plugin...";
         updateCenter.getPlugin('cas-plugin').deploy(true).get();
     }
 }
@@ -89,5 +87,5 @@ if (updateCenter.isRestartRequiredForCompletion()) {
 
 currentCasPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
 if (!isCasVersionSufficient(currentCasPluginVersion)) {
-  throw new Exception("Installed cas-plugin version " + currentCasPluginVersion + " is to old");
+  throw new Exception("Installed cas-plugin version " + currentCasPluginVersion + " is too old. It needs to be at least " + minimalCasPluginVersion);
 }

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -43,6 +43,12 @@ try {
 	println ex
 }
 
+//CAS-Plugin 1.4.3 --force
+def casPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
+if (casPluginVersion != "1.4.3") {
+	updateCenter.getPlugin('cas-plugin').deploy(true).get();
+}
+
 def availablePlugins = updateCenter.getAvailables();
 println "available plugins: " + availablePlugins.size()
 for (def shortName : plugins){

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -43,16 +43,6 @@ try {
 	println ex
 }
 
-//CAS-Plugin 1.4.3 --force
-def casPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
-def incompatibleCas = "1.4.3"
-if (casPluginVersion.compareTo(incompatibleCas) < 0) {
-  updateCenter.getPlugin('cas-plugin').deploy(true).get();
-}
-else {
-  println "CAS-Plugin is higher or equal to Version 1.4.3"
-}
-
 def availablePlugins = updateCenter.getAvailables();
 println "available plugins: " + availablePlugins.size()
 for (def shortName : plugins){
@@ -63,6 +53,16 @@ for (def shortName : plugins){
   } else {
     println "plugin not available or already installed : " + shortName
   }
+}
+
+// Make sure CAS-Plugin version is at least 1.4.3
+def casPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
+def incompatibleCas = "1.4.3"
+if (casPluginVersion.compareTo(incompatibleCas) < 0) {
+  updateCenter.getPlugin('cas-plugin').deploy(true).get();
+}
+else {
+  println "CAS-Plugin version is higher or equal to 1.4.3"
 }
 
 if (updateCenter.isRestartRequiredForCompletion()) {

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -56,12 +56,18 @@ for (def shortName : plugins){
 }
 
 // Make sure CAS-Plugin version is at least 1.4.3 to work with Jenkins 2.150.2 and following
-def enforcedCasPluginVersion = "1.4.3"
-def currentCasPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
-def sortedPluginVersions = [enforcedCasPluginVersion, currentCasPluginVersion].sort()
-if (sortedPluginVersions[0] != enforcedCasPluginVersion) {
-  println "CAS-Plugin version is lower than " + enforcedCasPluginVersion + "; Upgrading plugin..."
+def minimalCasPluginVersion = "1.4.3"
+def currentCasPlugin = jenkins.getPluginManager().getPlugin('cas-plugin');
+if (currentCasPlugin == null) {
+  println "CAS-Plugin is not installed; Installing plugin..."
   updateCenter.getPlugin('cas-plugin').deploy(true).get();
+} else {
+  def currentCasPluginVersion = currentCasPlugin.getVersion();
+  def sortedPluginVersions = [minimalCasPluginVersion, currentCasPluginVersion].sort()
+  if (sortedPluginVersions[0] != minimalCasPluginVersion) {
+    println "CAS-Plugin version is lower than " + minimalCasPluginVersion + "; Upgrading plugin..."
+    updateCenter.getPlugin('cas-plugin').deploy(true).get();
+  }
 }
 
 if (updateCenter.isRestartRequiredForCompletion()) {

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -44,8 +44,9 @@ try {
 }
 
 //CAS-Plugin 1.4.3 --force
-def casPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
-if (casPluginVersion != "1.4.3") {
+def casPluginVersion = jenkins.model.Jenkins.instance.getPluginManager().getPlugin('cas-plugin').getVersion();
+def incompatibleCas = "1.4.3"
+if (casPluginVersion.compareTo(incompatibleCas) < 0) {
 	updateCenter.getPlugin('cas-plugin').deploy(true).get();
 }
 

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -55,14 +55,13 @@ for (def shortName : plugins){
   }
 }
 
-// Make sure CAS-Plugin version is at least 1.4.3
-def casPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
-def incompatibleCas = "1.4.3"
-if (casPluginVersion.compareTo(incompatibleCas) < 0) {
+// Make sure CAS-Plugin version is at least 1.4.3 to work with Jenkins 2.150.2 and following
+def enforcedCasPluginVersion = "1.4.3"
+def currentCasPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
+def sortedPluginVersions = [enforcedCasPluginVersion, currentCasPluginVersion].sort()
+if (sortedPluginVersions[0] != enforcedCasPluginVersion) {
+  println "CAS-Plugin version is lower than " + enforcedCasPluginVersion + "; Upgrading plugin..."
   updateCenter.getPlugin('cas-plugin').deploy(true).get();
-}
-else {
-  println "CAS-Plugin version is higher or equal to 1.4.3"
 }
 
 if (updateCenter.isRestartRequiredForCompletion()) {

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -44,7 +44,7 @@ try {
 }
 
 //CAS-Plugin 1.4.3 --force
-def casPluginVersion = jenkins.model.Jenkins.instance.getPluginManager().getPlugin('cas-plugin').getVersion();
+def casPluginVersion = jenkins.getPluginManager().getPlugin('cas-plugin').getVersion();
 def incompatibleCas = "1.4.3"
 if (casPluginVersion.compareTo(incompatibleCas) < 0) {
   updateCenter.getPlugin('cas-plugin').deploy(true).get();

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -47,7 +47,10 @@ try {
 def casPluginVersion = jenkins.model.Jenkins.instance.getPluginManager().getPlugin('cas-plugin').getVersion();
 def incompatibleCas = "1.4.3"
 if (casPluginVersion.compareTo(incompatibleCas) < 0) {
-	updateCenter.getPlugin('cas-plugin').deploy(true).get();
+  updateCenter.getPlugin('cas-plugin').deploy(true).get();
+}
+else {
+  println "CAS-Plugin is higher or equal to Version 1.4.3"
 }
 
 def availablePlugins = updateCenter.getAvailables();

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init030installplugins.groovy
@@ -18,7 +18,7 @@ def keyExists(String key){
 }
 
 // Make sure CAS-Plugin version is at least 1.4.3 to work with Jenkins 2.150.2 and following
-def minimalCasPluginVersion = "1.4.3"
+minimalCasPluginVersion = "1.4.3"
 boolean isCasVersionSufficient(String version) {
     List minVer = minimalCasPluginVersion.tokenize('.')
     List testVer = version.tokenize('.')


### PR DESCRIPTION
Jenkins 2.150.2 needs the cas plugin with a version of at least 1.4.3 or else it will get stuck in a redirect loop. The changes in this PR will enforce this.
Resolves #25 