### PR TITLE
Handle alternative maven installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The init090NORMmavenautoinstall.groovy script does no longer crash when the default `M3` maven installer has been adjusted by the Jenkins administrator; #70
 
 ## [v2.235.5-2] - 2020-10-22
 ### Changed

--- a/integrationTests/init-scripts.spec.js
+++ b/integrationTests/init-scripts.spec.js
@@ -28,7 +28,7 @@ afterEach(async() => {
 });
 
 
-describe('user permissions', () => {
+describe('init scripts tests', () => {
     test('init090NORMmavenautoinstall: M3 maven installer has been created', async() => {
         await driver.get(utils.getCasUrl(driver));
         await adminFunctions.giveAdminRights();

--- a/integrationTests/init-scripts.spec.js
+++ b/integrationTests/init-scripts.spec.js
@@ -1,0 +1,49 @@
+const config = require('./config');
+const utils = require('./utils');
+const AdminFunctions = require('./adminFunctions');
+
+const webdriver = require('selenium-webdriver');
+const By = webdriver.By;
+const until = webdriver.until;
+
+jest.setTimeout(60000);
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+
+let driver;
+let adminFunctions;
+
+beforeEach(async() => {
+    driver = await utils.createDriver(webdriver);
+    await driver.manage().window().maximize();
+    adminFunctions = new AdminFunctions('testUser', 'testUser', 'testUser', 'testUser@test.de', 'testuserpassword');
+    await adminFunctions.createUser();
+});
+
+afterEach(async() => {
+    await driver.get(config.baseUrl + config.jenkinsContextPath + "/logout");
+    await adminFunctions.removeUser(driver);
+    await driver.quit();
+});
+
+
+describe('user permissions', () => {
+    test('init090NORMmavenautoinstall: M3 maven installer has been created', async() => {
+        await driver.get(utils.getCasUrl(driver));
+        await adminFunctions.giveAdminRights();
+        await adminFunctions.testUserLogin(driver);
+        await driver.wait(until.elementLocated(By.className('login')), 5000);
+
+        // go to tool configuration admin page
+        await driver.get(config.baseUrl + config.jenkinsContextPath + "/configureTools");
+        await driver.executeScript("window.scrollBy(0,1000)")
+        // click on maven installations button
+        await driver.wait(until.elementLocated(By.xpath("//button[contains(text(), 'Maven installations')]")),3000);
+        await driver.findElement(By.xpath("//button[contains(text(), 'Maven installations')]")).click();
+        // get all elements with "M3"
+        const elementsWithM3 = await driver.findElements(By.css("input[value='M3']"))
+        // there should be one occurence
+        expect(elementsWithM3.length == 1).toBe(true);
+    });
+});

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
@@ -17,10 +17,10 @@ import hudson.tools.*
 def mavenName = "M3"
 def targetVersion = "3.6.3"
 
-List<hudson.tasks.Maven$MavenInstallation> getInstallationsWithName(String name, List<hudson.tasks.Maven$MavenInstallation> installations){
+List<hudson.tasks.Maven$MavenInstallation> getMavenInstallationsWithName(String name, List<hudson.tasks.Maven$MavenInstallation> installations){
     List<hudson.tasks.Maven$MavenInstallation> installationsWithName = []
         installations?.each { installation ->
-        if (installation.toString().contains(name)) {
+        if (installation.toString() == "MavenInstallation[$name]") {
             installationsWithName.add(installation)
         }
     }
@@ -32,7 +32,7 @@ Collection<String> getInstalledMavenVersionsWithName(def mavenName) {
 
     def installations = Jenkins.instance.getDescriptor("hudson.tasks.Maven").getInstallations()
 
-    def m3Installations = getInstallationsWithName(mavenName, installations as List)
+    def m3Installations = getMavenInstallationsWithName(mavenName, installations as List)
     m3Installations?.each { installation ->
         installation.getProperties().each { property ->
             property.installers.each { installer ->
@@ -88,7 +88,7 @@ List getNonTargetM3Installations(def mavenName, def targetVersion) {
     def toRemove = []
 
     // iterate over every maven installation with $mavenName name
-    def installationsWithCorrectName = getInstallationsWithName(mavenName, mavenInstallationsList)
+    def installationsWithCorrectName = getMavenInstallationsWithName(mavenName, mavenInstallationsList)
     installationsWithCorrectName.each { installation ->
         def versions = []
         // find version ids of the installation, if any
@@ -122,7 +122,7 @@ void removeNonTargetM3Installations(List toRemove){
 int getAmountOfInstallationsWithCorrectName(String name){
     def mavenInstallations = Jenkins.instance.getExtensionList(hudson.tasks.Maven.DescriptorImpl.class)[0]
     def mavenInstallationsList = (mavenInstallations.installations as List)
-    def installationsWithCorrectName = getInstallationsWithName(name, mavenInstallationsList)
+    def installationsWithCorrectName = getMavenInstallationsWithName(name, mavenInstallationsList)
     return installationsWithCorrectName.size()
 }
 

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
@@ -27,25 +27,6 @@ List<hudson.tasks.Maven$MavenInstallation> getMavenInstallationsWithName(String 
     return installationsWithName
 }
 
-Collection<String> getInstalledMavenVersionsWithName(def mavenName) {
-    def versions = []
-
-    def installations = Jenkins.instance.getDescriptor("hudson.tasks.Maven").getInstallations()
-
-    def m3Installations = getMavenInstallationsWithName(mavenName, installations as List)
-    m3Installations?.each { installation ->
-        installation.getProperties().each { property ->
-            property.installers.each { installer ->
-                if (installer instanceof hudson.tasks.Maven$MavenInstaller){
-                    versions.add(installer.id)
-                }
-            }
-        }
-    }
-
-    return versions
-}
-
 static def createMavenInstallation(def mavenName, def mavenVersion) {
     def mvnInstaller = new Maven.MavenInstaller(mavenVersion)
     def instSourcProp = new InstallSourceProperty([mvnInstaller])

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
@@ -1,5 +1,9 @@
 // creates a global tool installer for maven.
 
+// This script creates a maven installer with the name defined below
+// or updates it, if it has not been altered by a Jenkins administrator.
+// Maven installations with other names are ignored
+
 // based on https://wiki.jenkins.io/display/JENKINS/Add+a+Maven+Installation%2C+Tool+Installation%2C+Modify+System+Config
 // more info https://github.com/glenjamin/jenkins-groovy-examples/blob/master/README.md
 
@@ -13,18 +17,27 @@ import hudson.tools.*
 def mavenName = "M3"
 def targetVersion = "3.6.3"
 
+List<hudson.tasks.Maven$MavenInstallation> getInstallationsWithName(String name, List<hudson.tasks.Maven$MavenInstallation> installations){
+    List<hudson.tasks.Maven$MavenInstallation> installationsWithName = []
+        installations?.each { installation ->
+        if (installation.toString().contains(name)) {
+            installationsWithName.add(installation)
+        }
+    }
+    return installationsWithName
+}
+
 Collection<String> getInstalledMavenVersionsWithName(def mavenName) {
     def versions = []
 
     def installations = Jenkins.instance.getDescriptor("hudson.tasks.Maven").getInstallations()
 
-    installations?.each { installation ->
-        if (installation.toString().contains(mavenName)) {
-            installation.getProperties().each { property ->
-                property.installers.each { installer ->
-                    if (installer instanceof hudson.tasks.Maven$MavenInstaller){
-                        versions.add(installer.id)
-                    }
+    def m3Installations = getInstallationsWithName(mavenName, installations as List)
+    m3Installations?.each { installation ->
+        installation.getProperties().each { property ->
+            property.installers.each { installer ->
+                if (installer instanceof hudson.tasks.Maven$MavenInstaller){
+                    versions.add(installer.id)
                 }
             }
         }
@@ -53,14 +66,15 @@ void addMavenToInstallations(def installation) {
 // hudson.tools.CommandInstaller or hudson.tools.BatchCommandInstaller.
 boolean propertyHasOneMavenInstallerOnly(def property) {
     int numberOfMavenInstallers = 0
+    boolean noOtherInstallerDetected = true
     property.installers.each { installer ->
         if (installer instanceof hudson.tasks.Maven$MavenInstaller){
             numberOfMavenInstallers++
         } else {
-            return false
+            noOtherInstallerDetected = false
         }
     }
-    return numberOfMavenInstallers == 1
+    return noOtherInstallerDetected && numberOfMavenInstallers == 1
 }
 
 // Gets Maven version as String if only one Maven installer is defined in property
@@ -68,35 +82,35 @@ String getSingleMavenInstallerVersion(def property){
     return property.installers[0].id
 }
 
-void removeNonTargetM3Installations(def mavenName, def targetVersion) {
+List getNonTargetM3Installations(def mavenName, def targetVersion) {
     def mavenInstallations = Jenkins.instance.getExtensionList(hudson.tasks.Maven.DescriptorImpl.class)[0]
     def mavenInstallationsList = (mavenInstallations.installations as List)
-
     def toRemove = []
 
-    // iterate over every maven installation
-    mavenInstallationsList.each { installation ->
-        // check only for installations named $mavenName
-        if (installation.toString().contains(mavenName)) {
-            def versions = []
-
-            // find version ids of the installation, if any
-            installation.getProperties().each { property ->
-                // Only get id if there is only one maven installer.
-                // More than one installer indicates settings modification by the user,
-                // which we do not want to remove
-                if (propertyHasOneMavenInstallerOnly(property)) {
-                    versions.add(getSingleMavenInstallerVersion(property))
-                }
-            }
-
-            // remember it as to be removed
-            if (!versions.contains(targetVersion)) {
-                toRemove.add(installation)
+    // iterate over every maven installation with $mavenName name
+    def installationsWithCorrectName = getInstallationsWithName(mavenName, mavenInstallationsList)
+    installationsWithCorrectName.each { installation ->
+        def versions = []
+        // find version ids of the installation, if any
+        installation.getProperties().each { property ->
+            // Only get id if there is only one maven installer.
+            // More than one installer indicates settings modification by the user,
+            // which we do not want to remove
+            if (propertyHasOneMavenInstallerOnly(property)) {
+                versions.add(getSingleMavenInstallerVersion(property))
             }
         }
+        // remember it as to be removed
+        if (!versions.isEmpty() && !versions.contains(targetVersion)) {
+            toRemove.add(installation)
+        }
     }
+    return toRemove
+}
 
+void removeNonTargetM3Installations(List toRemove){
+    def mavenInstallations = Jenkins.instance.getExtensionList(hudson.tasks.Maven.DescriptorImpl.class)[0]
+    def mavenInstallationsList = (mavenInstallations.installations as List)
     // remove all remembered installations
     toRemove.each { installation -> mavenInstallationsList.remove(installation) }
 
@@ -105,13 +119,36 @@ void removeNonTargetM3Installations(def mavenName, def targetVersion) {
     Jenkins.instance.save()
 }
 
+int getAmountOfInstallationsWithCorrectName(String name){
+    def mavenInstallations = Jenkins.instance.getExtensionList(hudson.tasks.Maven.DescriptorImpl.class)[0]
+    def mavenInstallationsList = (mavenInstallations.installations as List)
+    def installationsWithCorrectName = getInstallationsWithName(name, mavenInstallationsList)
+    return installationsWithCorrectName.size()
+}
+
 
 //// function definitions ready, work is done now:
 
-removeNonTargetM3Installations(mavenName, targetVersion)
-
-if (!getInstalledMavenVersionsWithName(mavenName).contains(targetVersion)) {
-    addMavenToInstallations(
+int amountOfMavenInstallationsWithCorrectName = getAmountOfInstallationsWithCorrectName(mavenName)
+switch (amountOfMavenInstallationsWithCorrectName) {
+    case 0:
+        println "Adding a new Maven installation with name $mavenName"
+        addMavenToInstallations(
             createMavenInstallation(mavenName, targetVersion)
-    )
+        )
+        break;
+    case 1:
+        def nonTargetMavenInstallations = getNonTargetM3Installations(mavenName, targetVersion)
+        if(!nonTargetMavenInstallations.isEmpty()){
+            println "Removing old Maven installation with name $mavenName"
+            removeNonTargetM3Installations(nonTargetMavenInstallations)
+            println "Adding a new Maven installation with name $mavenName and version $targetVersion"
+            addMavenToInstallations(
+                    createMavenInstallation(mavenName, targetVersion)
+            )
+        }
+        break;
+    default:
+        println "There is more than one installation with the name $mavenName present. Doing nothing."
+        break;
 }

--- a/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
+++ b/resources/var/tmp/resources/init.groovy.d/scripts/init090NORMmavenautoinstall.groovy
@@ -46,10 +46,7 @@ void addMavenToInstallations(def installation) {
 // Other possible installers are hudson.tools.ZipExtractionInstaller,
 // hudson.tools.CommandInstaller or hudson.tools.BatchCommandInstaller.
 boolean propertyHasOneMavenInstallerOnly(def property) {
-    if (property.installers.size() != 1 || !(property.installers[0] instanceof hudson.tasks.Maven$MavenInstaller)) {
-        return false
-    }
-    return true
+    return (property.installers.size() == 1 && (property.installers[0] instanceof hudson.tasks.Maven$MavenInstaller))
 }
 
 // Gets Maven version as String if only one Maven installer is defined in property


### PR DESCRIPTION
The init090NORMmavenautoinstall.groovy script does no longer crash when the default `M3` maven installer has been adjusted by the Jenkins administrator.

Resolves #70 