### PR TITLE
Optimization of MaxHeapSize with Docker-based memory limiting capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to set memory limit via `cesapp edit-config`
+- Optimized max heap size in limited dockerized environments (#58)
+
 ## [v2.249.3-1] - 2020-11-16
 ### Changed
 - Upgrade to Jenkins 2.249.3 LTS; #72

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ability to set memory limit via `cesapp edit-config`
-- Optimized max heap size in limited dockerized environments (#58)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the CAS process inside the container via `cesapp edit-conf` (#74)
 
 ## [v2.249.3-1] - 2020-11-16
 ### Changed

--- a/dogu.json
+++ b/dogu.json
@@ -46,6 +46,22 @@
       "Name": "additional.plugins",
       "Description": "Comma separated list of plugin names to install on start",
       "Optional": true
+    },
+    {
+      "Name": "container_config/memory_limit",
+      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 3g of memory for Jenkins.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description":"Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
     }
   ],
   "ExposedCommands": [

--- a/dogu.json
+++ b/dogu.json
@@ -49,7 +49,7 @@
     },
     {
       "Name": "container_config/memory_limit",
-      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend at least 3g of memory for Jenkins.",
+      "Description":"Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
@@ -61,6 +61,24 @@
       "Optional": true,
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/java_max_ram_percentage",
+      "Description":"Limits the heap stack size of the Jenkins process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Jenkins: 25%",
+      "Optional": true,
+      "Default": "25.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_min_ram_percentage",
+      "Description":"Limits the heap stack size of the Jenkins process to the configured percentage of the available physical memory when the container has less than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for Jenkins: 50%",
+      "Optional": true,
+      "Default": "50.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
       }
     }
   ],

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -60,10 +60,24 @@ if [[ ! -e /var/lib/jenkins/.mavenrc ]]; then
 fi
 
 # starting jenkins
-java -Djava.awt.headless=true \
-  -Djava.net.preferIPv4Stack=true \
-  -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
-  -Djavax.net.ssl.trustStorePassword=changeit \
-  -Djenkins.install.runSetupWizard=false \
-  -Djava.awt.headless=true \
-  -jar /jenkins.war --prefix=/jenkins
+if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" == "empty" ]];  then
+  echo "Starting Jenkins without memory limits..."
+  java -Djava.awt.headless=true \
+    -Djava.net.preferIPv4Stack=true \
+    -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
+    -Djavax.net.ssl.trustStorePassword=changeit \
+    -Djenkins.install.runSetupWizard=false \
+    -Djava.awt.headless=true \
+    -jar /jenkins.war --prefix=/jenkins
+else
+  echo "Starting Jenkins with memory limits..."
+  java -Djava.awt.headless=true \
+    -Djava.net.preferIPv4Stack=true \
+    -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
+    -Djavax.net.ssl.trustStorePassword=changeit \
+    -Djenkins.install.runSetupWizard=false \
+    -Djava.awt.headless=true \
+    -XX:MaxRAMPercentage=85.0 \
+    -XX:MinRAMPercentage=50.0 \
+    -jar /jenkins.war --prefix=/jenkins
+fi

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -70,14 +70,17 @@ if [[ "$(doguctl config "container_config/memory_limit" -d "empty")" == "empty" 
     -Djava.awt.headless=true \
     -jar /jenkins.war --prefix=/jenkins
 else
-  echo "Starting Jenkins with memory limits..."
+  # Retrieve configurable java limits from etcd, valid default values exist
+  MEMORY_LIMIT_MAX_PERCENTAGE=$(doguctl config "container_config/java_max_ram_percentage")
+  MEMORY_LIMIT_MIN_PERCENTAGE=$(doguctl config "container_config/java_min_ram_percentage")
+  echo "Starting Jenkins with memory limits: MaxRAMPercentage=${MEMORY_LIMIT_MAX_PERCENTAGE}, MinRAMPercentage=${MEMORY_LIMIT_MIN_PERCENTAGE} ..."
   java -Djava.awt.headless=true \
     -Djava.net.preferIPv4Stack=true \
     -Djavax.net.ssl.trustStore="${TRUSTSTORE}" \
     -Djavax.net.ssl.trustStorePassword=changeit \
     -Djenkins.install.runSetupWizard=false \
     -Djava.awt.headless=true \
-    -XX:MaxRAMPercentage=85.0 \
-    -XX:MinRAMPercentage=50.0 \
+    -XX:MaxRAMPercentage="${MEMORY_LIMIT_MAX_PERCENTAGE}" \
+    -XX:MinRAMPercentage="${MEMORY_LIMIT_MIN_PERCENTAGE}" \
     -jar /jenkins.war --prefix=/jenkins
 fi


### PR DESCRIPTION
Fixes #74 

With Docker-based memory limiting capabilities, it is possible to restrict the memory for the Jenkins-Dogu. Since version 10, Java can automatically detect container limits. However, Java generally only claims 25% of the physical memory (of the container) as the maximum heap size. This issue aims to optimize the maximum heap size while considering interferences with other possible programs in the container.

Set the MaxRamPercentage and MinRamPercentage to recommended values:
MaxRamPercentage=85.0
MinRamPercentage=50.0