### PR TITLE
Add Changelog check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Update dogu-build-lib to `v1.1.1`
-- Update zalenium-build-lib to `v2.1.0`
-- toggle video recording with build parameter (#76)
-
 ## [v2.249.3-2] - 2020-12-14
-
 ### Added
-
 - Ability to set memory limit via `cesapp edit-config`
 - Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the CAS process inside the container via `cesapp edit-conf` (#74)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Changed
-
 - Update dogu-build-lib to `v1.1.1`
 - Update zalenium-build-lib to `v2.1.0`
-- toggle video recording with build parameter (#76)
-
-## [v2.249.3-2] - 2020-12-14
+- Toggle video recording with build parameter (#76)
 
 ### Added
+- Check if changelog has been extended on a Jenkins build for a pull request branch
 
+## [v2.249.3-2] - 2020-12-14
+### Added
 - Ability to set memory limit via `cesapp edit-config`
 - Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the CAS process inside the container via `cesapp edit-conf` (#74)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update dogu-build-lib to `v1.1.1`
+- Update zalenium-build-lib to `v2.1.0`
+- toggle video recording with build parameter (#76)
+
 ## [v2.249.3-2] - 2020-12-14
+
 ### Added
+
 - Ability to set memory limit via `cesapp edit-config`
 - Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the CAS process inside the container via `cesapp edit-conf` (#74)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ node('vagrant') {
                 echo 'This is a pull request; checking changelog...'
                 String newChanges = changelog.changesForVersion('Unreleased')
                 if (!newChanges || newChanges.allWhitespace) {
-                    unstable('There is no information about unreleased changes in the CHANGELOG.md')
+                    unstable('CHANGELOG.md should contain new change entries in the `[Unreleased]` section but none were found.')
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node('vagrant') {
     GitHub github = new GitHub(this, git)
     Changelog changelog = new Changelog(this)
 
-    timestamps{
+    timestamps {
         properties([
             // Keep only the last x builds to preserve space
             buildDiscarder(logRotator(numToKeepStr: '10')),
@@ -43,8 +43,13 @@ node('vagrant') {
 
         try {
 
+            stage('Check changelog') {
+                String newChanges = changelog.changesForVersion('Unreleased')
+                echo 'DEBUG: NEW CHANGES:' + newChanges
+            }
+
             stage('Provision') {
-                ecoSystem.provision("/dogu");
+                ecoSystem.provision("/dogu")
             }
 
             stage('Setup') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@ node('vagrant') {
     GitFlow gitflow = new GitFlow(this, git)
     GitHub github = new GitHub(this, git)
     Changelog changelog = new Changelog(this)
-    branch = "${env.BRANCH_NAME}"
 
     timestamps {
         properties([
@@ -40,7 +39,7 @@ node('vagrant') {
             shellCheck("resources/startup.sh resources/upgrade-notification.sh resources/pre-upgrade.sh")
 
             if (env.CHANGE_TARGET) {
-                // This branch has been detected as a pull request
+                echo 'This is a pull request; checking changelog...'
                 String newChanges = changelog.changesForVersion('Unreleased')
                 if (!newChanges || newChanges.allWhitespace) {
                     unstable('There is no information about unreleased changes in the CHANGELOG.md')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ node('vagrant') {
     GitFlow gitflow = new GitFlow(this, git)
     GitHub github = new GitHub(this, git)
     Changelog changelog = new Changelog(this)
+    branch = "${env.BRANCH_NAME}"
 
     timestamps {
         properties([
@@ -44,8 +45,13 @@ node('vagrant') {
         try {
 
             stage('Check changelog') {
-                String newChanges = changelog.changesForVersion('Unreleased')
-                echo 'DEBUG: NEW CHANGES:' + newChanges
+                if (env.CHANGE_TARGET) {
+                    // This branch has been detected as a pull request
+                    String newChanges = changelog.changesForVersion('Unreleased')
+                    if (!newChanges || newChanges.allWhitespace) {
+                        unstable('There is no information about unreleased changes in the CHANGELOG.md')
+                    }
+                }
             }
 
             stage('Provision') {


### PR DESCRIPTION
This PR adds a check to the Lint stage that checks if there is information provided inside the `Unreleased` section in the CHANGELOG.md if the Jenkins job is run for a PR branch. If the information is missing, the build is marked as unstable.