### PR TITLE
Upgrade tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add trivy scan in Jenkins pipeline
+
 ### Changed
 - Upgrade to java base image 11.0.18-1
 - Upgrade additional OpenJDK8 to 8.362.09-r1
 - Upgrade glibc to 2.35-r1
+- Upgrade ces-build-lib to 1.64.2
+- Upgrade dogu-build-lib to 2.1.0
 
 ## [v2.387.1-1] - 2023-03-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Upgrade to java base image 11.0.18-1
+- Upgrade additional OpenJDK8 to 8.362.09-r1
+- Upgrade glibc to 2.35-r1
 
 ## [v2.387.1-1] - 2023-03-13
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # cesi/scm
-FROM registry.cloudogu.com/official/java:11.0.14-3
+FROM registry.cloudogu.com/official/java:11.0.18-1
 
 LABEL NAME="official/jenkins" \
       VERSION="2.387.1-1" \
@@ -14,13 +14,13 @@ ENV JENKINS_HOME=/var/lib/jenkins \
     # jenkins version
     JENKINS_VERSION=2.387.1 \
     # glibc for alpine version
-    GLIBC_VERSION=2.33-r0 \
-    SHA256_GLIB_APK="3ce2b708b17841bc5978da0fa337fcb90fec5907daa396585db68805754322e0" \
-    SHA256_GLIB_BIN_APK="f862ce6d61b294859f3facd1dae347e7bc5e36714649a37d2a785e7d7a3af84e" \
-    SHA256_GLIB_I18N_APK="be3a55e6366a2ddaecf17203a7e71966757dca47a25ce34b5f3d6dd1e1efee55" \
+    GLIBC_VERSION=2.35-r1 \
+    SHA256_GLIB_APK="276f43ce9b2d5878422bca94ca94e882a7eb263abe171d233ac037201ffcaf06" \
+    SHA256_GLIB_BIN_APK="ee13b7e482f92142d2bec7c4cf09ca908e6913d4782fa35691cad1d9c23f179a" \
+    SHA256_GLIB_I18N_APK="94c6f9ed13903b59d5c524c0c2ec9a24ef1a4c2aaa93a8a158465a9e819a8065" \
     SHA256_JENKINS_WAR="c132a1e00b685afc7996eba530be428a3279c649399417f9fa38fcbc0dbec027" \
     # additional java version for legacy builds
-    ADDITIONAL_OPENJDK_VERSION="8.345.01-r0"
+    ADDITIONAL_OPENJDK_VERSION="8.362.09-r1"
 
 # Jenkins is ran with user `jenkins`, uid = 1000
 # If you bind mount a volume from host/volume from a data container,
@@ -35,7 +35,7 @@ RUN set -o errexit \
  # install coreutils, ttf-dejavu, openssh and scm clients
  # coreutils and ttf-dejavu is required because of java.awt.headless problem:
  # - https://wiki.jenkins.io/display/JENKINS/Jenkins+got+java.awt.headless+problem
- && apk add --no-cache coreutils ttf-dejavu openssh-client git subversion mercurial \
+ && apk add --no-cache coreutils ttf-dejavu openssh-client git subversion mercurial curl \
  && apk add openjdk8="$ADDITIONAL_OPENJDK_VERSION" \
  # could use ADD but this one does not check Last-Modified header
  # see https://github.com/docker/docker/issues/8331
@@ -66,6 +66,7 @@ RUN set -o errexit \
  && echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh \
  && /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib \
  # cleanup
+ && apk del curl \
  && rm -rf /tmp/* /var/cache/apk/*
 
 # Jenkins home directoy is a volume, so configuration and build history

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@1.62.0', 'github.com/cloudogu/dogu-build-lib@v2.0.0'])
+@Library(['github.com/cloudogu/ces-build-lib@1.64.2', 'github.com/cloudogu/dogu-build-lib@v2.1.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 
@@ -27,10 +27,13 @@ node('vagrant') {
                 string(defaultValue: '', description: 'Old Dogu version for the upgrade test (optional; e.g. 2.222.1-1)', name: 'OldDoguVersionForUpgradeTest'),
                 booleanParam(defaultValue: false, description: 'Enables the video recording during the test execution', name: 'EnableVideoRecording'),
                 booleanParam(defaultValue: false, description: 'Enables the screenshot recording during the test execution', name: 'EnableScreenshotRecording'),
+                choice(name: 'TrivyScanLevels', choices: [TrivyScanLevel.CRITICAL, TrivyScanLevel.HIGH, TrivyScanLevel.MEDIUM, TrivyScanLevel.ALL], description: 'The levels to scan with trivy'),
+                choice(name: 'TrivyStrategy', choices: [TrivyScanStrategy.UNSTABLE, TrivyScanStrategy.FAIL, TrivyScanStrategy.IGNORE], description: 'Define whether the build should be unstable, fail or whether the error should be ignored if any vulnerability was found.'),
             ])
         ])
 
         EcoSystem ecoSystem = new EcoSystem(this, "gcloud-ces-operations-internal-packer", "jenkins-gcloud-ces-operations-internal")
+	Trivy trivy = new Trivy(this, ecoSystem)
 
         stage('Checkout') {
             checkout scm
@@ -78,6 +81,12 @@ node('vagrant') {
 
             stage('Build') {
                 ecoSystem.build("/dogu")
+            }
+
+            stage('Trivy scan') {
+                trivy.scanDogu("/dogu", TrivyScanFormat.HTML, params.TrivyScanLevels, params.TrivyStrategy)
+                trivy.scanDogu("/dogu", TrivyScanFormat.JSON,  params.TrivyScanLevels, params.TrivyStrategy)
+                trivy.scanDogu("/dogu", TrivyScanFormat.PLAIN, params.TrivyScanLevels, params.TrivyStrategy)
             }
 
             stage('Verify') {


### PR DESCRIPTION
### Added
- Add trivy scan in Jenkins pipeline

### Changed
- Upgrade to java base image 11.0.18-1
- Upgrade additional OpenJDK8 to 8.362.09-r1
- Upgrade glibc to 2.35-r1
- Upgrade ces-build-lib to 1.64.2
- Upgrade dogu-build-lib to 2.1.0