### PR TITLE
Added version check for CAS dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The internal makefiles have been updated to standardize the versioning of the release notes.
 
+### Added
+- Dependency version check for CAS, as version >=7.0.5.1-4 of CAS is required for service accounts with type cas
+
 ## [v2.462.3-2] - 2024-11-15
 ### Fixed
 - Fix reading dogu config for key updateSiteUrl; #180

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -6,8 +6,8 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 
 ## [Unreleased]
 ### Changed
-* Die internen Makefiles wurden aktualisiert um die Versionierung der Release-Notes zu vereinheitlichen. 
-* Ein Versionsprüfung für das CAS-Dogu wurde hinzugefügt, da Jenkins ab v2.462.3-1 eine CAS-Version >=7.0.5.1-4 benötigt für die Erstellung von Serviceaccounts
+* Die internen Makefiles wurden aktualisiert, um die Versionierung der Release-Notes zu vereinheitlichen. 
+* Eine Versionsprüfung für das CAS-Dogu wurde hinzugefügt, da Jenkins ab v2.462.3-1 eine CAS-Version >=7.0.5.1-4 benötigt für die Erstellung von Serviceaccounts
 
 ## 2.462.3-2
 * Es wurde ein Bugfix behoben, bei dem die Einträge aus der Dogu-Konfiguration für updateSiteUrl nicht in Jenkins übernommen wurden.

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -7,6 +7,7 @@ Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https
 ## [Unreleased]
 ### Changed
 * Die internen Makefiles wurden aktualisiert um die Versionierung der Release-Notes zu vereinheitlichen. 
+* Ein Versionsprüfung für das CAS-Dogu wurde hinzugefügt, da Jenkins ab v2.462.3-1 eine CAS-Version >=7.0.5.1-4 benötigt für die Erstellung von Serviceaccounts
 
 ## 2.462.3-2
 * Es wurde ein Bugfix behoben, bei dem die Einträge aus der Dogu-Konfiguration für updateSiteUrl nicht in Jenkins übernommen wurden.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -7,6 +7,7 @@ Technical details on a release can be found in the corresponding [Changelog](htt
 ## [Unreleased]
 ### Changed
 * The internal makefiles have been updated to standardize the versioning of the release notes.
+* A version check has been added for the CAS dogu, as Jenkins since version v2.462.3-1 needs the CAS dogu in version >=7.0.5.1-4 to create service accounts
 
 ## 2.462.3-2
 * Fixed a bug where the entries from the Dogu configuration for updateSiteUrl were not applied to Jenkins.

--- a/dogu.json
+++ b/dogu.json
@@ -16,7 +16,8 @@
   "Dependencies": [
     {
       "type": "dogu",
-      "name": "cas"
+      "name": "cas",
+      "version": ">=7.0.5.1-4"
     },
     {
       "type": "dogu",


### PR DESCRIPTION
Jenkins since version v2.462.3-1 needs the CAS dogu in version >=7.0.5.1-4 to create service accounts. Without the check post-upgrade fails when an older version of CAS is installed.